### PR TITLE
Feature/add compose preview

### DIFF
--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/Appbar.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/Appbar.kt
@@ -10,7 +10,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.ui.icon.UniversityIcons
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 import com.kitabisa.test.universitydomains.core.util.IntentUtils
 import com.kitabisa.test.universitydomains.core.util.Urls
 
@@ -38,4 +42,14 @@ fun Appbar(
             }
         }
     )
+}
+
+@Preview
+@Composable
+fun AppbarPreview() {
+    UniversityDomainsTheme {
+        Appbar(
+            title = stringResource(R.string.feature_home_title)
+        )
+    }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/EmptyState.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/EmptyState.kt
@@ -13,9 +13,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun EmptyState(
@@ -50,5 +54,16 @@ fun EmptyState(
                 textAlign = TextAlign.Center
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun EmptyStatePreview() {
+    UniversityDomainsTheme {
+        EmptyState(
+            title = stringResource(R.string.feature_home_empty_title),
+            message = stringResource(R.string.feature_home_empty_message)
+        )
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/ErrorState.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/ErrorState.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun ErrorState(
@@ -58,5 +60,13 @@ fun ErrorState(
                 Text(text = stringResource(R.string.error_button_retry))
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorStatePreview() {
+    UniversityDomainsTheme {
+        ErrorState()
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/IdleState.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/IdleState.kt
@@ -15,9 +15,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun IdleState(
@@ -50,5 +52,13 @@ fun IdleState(
                 textAlign = TextAlign.Center
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun IdleStatePreview() {
+    UniversityDomainsTheme {
+        IdleState()
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/LoadingState.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/LoadingState.kt
@@ -7,7 +7,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun LoadingState(modifier: Modifier = Modifier) {
@@ -18,5 +20,13 @@ fun LoadingState(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center
     ) {
         CircularProgressIndicator()
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingStatePreview() {
+    UniversityDomainsTheme {
+        LoadingState()
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/RecentSearchItem.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/RecentSearchItem.kt
@@ -5,14 +5,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.icon.UniversityIcons
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun RecentSearchItem(
@@ -28,9 +33,30 @@ fun RecentSearchItem(
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(recent)
-        IconButton(onClick = { onRemoveRecentSearchClick(recent) }) {
+        Text(
+            text = recent,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 8.dp)
+        )
+        IconButton(
+            modifier = Modifier.wrapContentSize(),
+            onClick = { onRemoveRecentSearchClick(recent) }) {
             Icon(imageVector = UniversityIcons.Clear, contentDescription = "Remove")
         }
+    }
+}
+
+@Preview
+@Composable
+private fun RecentSearchItemPreview() {
+    UniversityDomainsTheme {
+        RecentSearchItem(
+            recent = UniversityTestData.recentSearch.first(),
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/RecentState.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/RecentState.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.component.RecentSearchItem
 import com.kitabisa.test.universitydomains.core.ui.component.RecentSearchLabel
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun RecentState(
@@ -30,5 +33,18 @@ fun RecentState(
                 onRemoveRecentSearchClick = onRemoveRecentSearchClick
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun RecentStatePreview() {
+    UniversityDomainsTheme {
+        RecentState(
+            recentSearches = UniversityTestData.recentSearch,
+            onClearRecentSearches = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/RecentsearchLabel.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/RecentsearchLabel.kt
@@ -12,13 +12,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kitabisa.test.universitydomains.R
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun RecentSearchLabel(
-    onClearClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClearClick: () -> Unit
 ) {
     Row(
         modifier = modifier
@@ -34,5 +36,13 @@ fun RecentSearchLabel(
         TextButton(onClick = onClearClick) {
             Text(stringResource(R.string.feature_search_recent_clear))
         }
+    }
+}
+
+@Preview
+@Composable
+private fun RecentSearchLabelPreview() {
+    UniversityDomainsTheme {
+        RecentSearchLabel {}
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/SearchAppBar.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/SearchAppBar.kt
@@ -23,8 +23,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
 import com.kitabisa.test.universitydomains.R
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.icon.UniversityIcons
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,4 +91,30 @@ fun SearchAppBar(
             }
         }
     )
+}
+
+@Preview
+@Composable
+private fun SearchAppBarWithQueryPreview() {
+    UniversityDomainsTheme {
+        SearchAppBar(
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRefreshClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SearchAppBarEmptyPreview() {
+    UniversityDomainsTheme {
+        SearchAppBar(
+            query = TextFieldValue(""),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRefreshClick = {}
+        )
+    }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/UniversityFeed.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/UniversityFeed.kt
@@ -8,8 +8,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kitabisa.test.universitydomains.core.model.SavableUniversity
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun UniversityFeed(
@@ -30,5 +33,15 @@ fun UniversityFeed(
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun UniversityFeedPreview() {
+    UniversityDomainsTheme {
+        UniversityFeed(
+            savableUniversities = UniversityTestData.savableUniversities
+        ) {}
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/UniversityItem.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/core/ui/component/UniversityItem.kt
@@ -19,9 +19,12 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kitabisa.test.universitydomains.core.model.SavableUniversity
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.icon.UniversityIcons
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 import com.kitabisa.test.universitydomains.core.util.IntentUtils
 import com.kitabisa.test.universitydomains.core.util.countryCodeToEmojiFlag
 
@@ -90,5 +93,25 @@ fun UniversityItem(
                 tint = if (savableUniversity.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun UniversityItemNotFavoritePreview() {
+    UniversityDomainsTheme {
+        UniversityItem(
+            savableUniversity = UniversityTestData.savableUniversities.first()
+        ) {}
+    }
+}
+
+@Preview
+@Composable
+private fun UniversityItemFavoritePreview() {
+    UniversityDomainsTheme {
+        UniversityItem(
+            savableUniversity = UniversityTestData.favoriteSavableUniversities.first()
+        ) {}
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/feature/favorite/FavoriteScreen.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/feature/favorite/FavoriteScreen.kt
@@ -10,15 +10,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.model.SavableUniversity
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.component.Appbar
 import com.kitabisa.test.universitydomains.core.ui.component.EmptyState
 import com.kitabisa.test.universitydomains.core.ui.component.ErrorState
 import com.kitabisa.test.universitydomains.core.ui.component.LoadingState
 import com.kitabisa.test.universitydomains.core.ui.component.UniversityFeed
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 import com.kitabisa.test.universitydomains.navigation.TopLevelDestination
 
 @Composable
@@ -79,5 +82,53 @@ fun FavoriteScreen(
                 }
             }
         }
+    }
+}
+
+@Preview()
+@Composable
+private fun FavoriteScreenSuccessPreview() {
+    UniversityDomainsTheme {
+        FavoriteScreen(
+            uiState = FavoriteUiState.Success(UniversityTestData.favoriteSavableUniversities),
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview()
+@Composable
+private fun FavoriteScreenLoadingPreview() {
+    UniversityDomainsTheme {
+        FavoriteScreen(
+            uiState = FavoriteUiState.Loading,
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview()
+@Composable
+private fun FavoriteScreenErrorPreview() {
+    UniversityDomainsTheme {
+        FavoriteScreen(
+            uiState = FavoriteUiState.Error(UniversityTestData.errorMessage),
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview()
+@Composable
+private fun FavoriteScreenEmptyPreview() {
+    UniversityDomainsTheme {
+        FavoriteScreen(
+            uiState = FavoriteUiState.Empty,
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/feature/home/HomeScreen.kt
@@ -17,15 +17,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.model.SavableUniversity
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.component.Appbar
 import com.kitabisa.test.universitydomains.core.ui.component.EmptyState
 import com.kitabisa.test.universitydomains.core.ui.component.ErrorState
 import com.kitabisa.test.universitydomains.core.ui.component.LoadingState
 import com.kitabisa.test.universitydomains.core.ui.component.UniversityFeed
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 import com.kitabisa.test.universitydomains.navigation.TopLevelDestination
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -112,5 +115,80 @@ fun HomeScreen(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview()
+@Composable
+private fun HomeScreenSuccessPreview() {
+    UniversityDomainsTheme {
+        HomeScreen(
+            uiState = HomeUiState.Success(UniversityTestData.savableUniversities),
+            isRefreshing = false,
+            onRefresh = {},
+            onFavoriteClick = {},
+            onRetryClick = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview()
+@Composable
+private fun HomeScreenLoadingPreview() {
+    UniversityDomainsTheme {
+        HomeScreen(
+            uiState = HomeUiState.Loading,
+            isRefreshing = false,
+            onRefresh = {},
+            onFavoriteClick = {},
+            onRetryClick = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview()
+@Composable
+private fun HomeScreenErrorPreview() {
+    UniversityDomainsTheme {
+        HomeScreen(
+            uiState = HomeUiState.Error(UniversityTestData.errorMessage),
+            isRefreshing = false,
+            onRefresh = {},
+            onFavoriteClick = {},
+            onRetryClick = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview()
+@Composable
+private fun HomeScreenEmptyPreview() {
+    UniversityDomainsTheme {
+        HomeScreen(
+            uiState = HomeUiState.Empty,
+            isRefreshing = false,
+            onRefresh = {},
+            onFavoriteClick = {},
+            onRetryClick = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview()
+@Composable
+private fun HomeScreenRefreshingPreview() {
+    UniversityDomainsTheme {
+        HomeScreen(
+            uiState = HomeUiState.Success(UniversityTestData.savableUniversities),
+            isRefreshing = true,
+            onRefresh = {},
+            onFavoriteClick = {},
+            onRetryClick = {},
+        )
     }
 }

--- a/app/src/main/java/com/kitabisa/test/universitydomains/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/kitabisa/test/universitydomains/feature/search/SearchScreen.kt
@@ -11,17 +11,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ajaib.assessment.github.core.ui.RecentState
 import com.kitabisa.test.universitydomains.R
 import com.kitabisa.test.universitydomains.core.model.SavableUniversity
 import com.kitabisa.test.universitydomains.core.testing.constant.TestTag
+import com.kitabisa.test.universitydomains.core.testing.data.UniversityTestData
 import com.kitabisa.test.universitydomains.core.ui.component.EmptyState
 import com.kitabisa.test.universitydomains.core.ui.component.ErrorState
 import com.kitabisa.test.universitydomains.core.ui.component.IdleState
 import com.kitabisa.test.universitydomains.core.ui.component.LoadingState
 import com.kitabisa.test.universitydomains.core.ui.component.SearchAppBar
 import com.kitabisa.test.universitydomains.core.ui.component.UniversityFeed
+import com.kitabisa.test.universitydomains.core.ui.theme.UniversityDomainsTheme
 
 @Composable
 fun SearchScreen(
@@ -119,5 +122,119 @@ fun SearchScreen(
                 }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+fun SearchScreenSuccessPreview() {
+    UniversityDomainsTheme {
+        SearchScreen(
+            searchResultUiState = SearchResultUiState.Success(UniversityTestData.universitiesFilterByQuery),
+            recentSearchesUiState = RecentSearchesUiState.Empty,
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {},
+            onClearRecentSearches = {},
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SearchScreenLoadingPreview() {
+    UniversityDomainsTheme {
+        SearchScreen(
+            searchResultUiState = SearchResultUiState.Loading,
+            recentSearchesUiState = RecentSearchesUiState.Empty,
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {},
+            onClearRecentSearches = {},
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SearchScreenErrorPreview() {
+    UniversityDomainsTheme {
+        SearchScreen(
+            searchResultUiState = SearchResultUiState.Error(UniversityTestData.errorMessage),
+            recentSearchesUiState = RecentSearchesUiState.Empty,
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {},
+            onClearRecentSearches = {},
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SearchScreenEmptyPreview() {
+    UniversityDomainsTheme {
+        SearchScreen(
+            searchResultUiState = SearchResultUiState.Empty,
+            recentSearchesUiState = RecentSearchesUiState.Empty,
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {},
+            onClearRecentSearches = {},
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SearchScreenIdlePreview() {
+    UniversityDomainsTheme {
+        SearchScreen(
+            searchResultUiState = SearchResultUiState.Idle,
+            recentSearchesUiState = RecentSearchesUiState.Empty,
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {},
+            onClearRecentSearches = {},
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SearchScreenRecentPreview() {
+    UniversityDomainsTheme {
+        SearchScreen(
+            searchResultUiState = SearchResultUiState.Idle,
+            recentSearchesUiState = RecentSearchesUiState.Recent(UniversityTestData.recentSearch),
+            query = TextFieldValue(UniversityTestData.query),
+            onQueryChange = {},
+            onSearchTriggered = {},
+            onRecentSearchClick = {},
+            onRemoveRecentSearchClick = {},
+            onClearRecentSearches = {},
+            onFavoriteClick = {},
+            onRetryClick = {}
+        )
     }
 }


### PR DESCRIPTION
### Description
This PR introduces `@Preview` annotations to visualize various states of the HomeScreen, SearchScreen, and FavoriteScreen in Jetpack Compose. These previews aim to enhance the development workflow by enabling real-time validation of UI components across different states directly within the Android Studio design editor.

---

### Changes Made
#### HomeScreen Previews
- **States**: Success, Loading, Error, Empty, Refreshing
- Added scenarios to visualize the HomeScreen UI for different data and interaction states.

#### SearchScreen Previews
- **States**: Success, Loading, Error, Empty, Idle, Recent Searches
- Implemented comprehensive previews for the SearchScreen to simulate different user interactions and results.

#### FavoriteScreen Previews
- **States**: Success, Loading, Error, Empty
- Enabled previews to validate the FavoriteScreen UI for various data and interaction conditions.

---

### Visual References
#### HomeScreen Previews
- **Success State**: Displays a list of universities.
- **Loading State**: Simulates the loading indicator.
- **Error State**: Shows an error message and retry button.
- **Empty State**: Indicates no universities are available.
- **Refreshing State**: Displays the loading spinner with existing content.

#### SearchScreen Previews
- **Idle State**: Indicates a blank search bar.
- **Recent Searches**: Displays recent search history.
- **Success State**: Shows search results.
- **Loading State**: Displays the loading indicator.
- **Error State**: Indicates an error occurred during the search.
- **Empty State**: Indicates no search results.

#### FavoriteScreen Previews
- **Success State**: Displays a list of favorite universities.
- **Loading State**: Simulates the loading indicator.
- **Error State**: Shows an error message and retry button.
- **Empty State**: Indicates no favorite universities are available.

---

### Screen Recordings
#### HomeScreen Previews
<img width="1193" alt="Screenshot 2025-01-04 at 07 35 40" src="https://github.com/user-attachments/assets/9b4cd6f1-74ed-43e0-9214-e199c4a49a95" />

#### SearchScreen Previews
<img width="1301" alt="Screenshot 2025-01-04 at 07 36 09" src="https://github.com/user-attachments/assets/f05f1292-b4a1-4764-a48b-1f59527bef99" />

#### FavoriteScreen Previews
<img width="832" alt="Screenshot 2025-01-04 at 07 34 49" src="https://github.com/user-attachments/assets/02fe7edf-e8e5-43b2-984d-b1a2d3439588" />


---

### Checklist
- [x] Previews added for HomeScreen
- [x] Previews added for SearchScreen
- [x] Previews added for FavoriteScreen
- [x] Verified UI states in the design editor
- [x] Updated relevant components to support previews